### PR TITLE
feat: Start without Docker Swarm and secrets. Update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,17 @@ Use the `AZURE_STORAGE_CONTAINER` env var to select the container from which to 
 Note that the script will NOT run if the postgres_data directory already contains a database. This is exactly as we want to behave, as we only need to restore the DB if it does not exist.
 
 Make sure the `AZURE_STORAGE_KEY` and `AZURE_STORAGE_ACCOUNT` secrets are set through Docker with appropriate values so that the script can access the dump.
+
+## Running locally without Docker Swarm.
+
+You can also run the image locally without using Docker Swarm and Secrets by setting the `AZURE_STORAGE_KEY`, `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_CONTAINER` as environment variables on container startup.
+
+Build image:
+```
+docker build -t hsl-jore-postgis .
+```
+```
+docker run -d -p 5432:5432 --name hsl-jore-postgis -v jore-data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=postgres -e AZURE_STORAGE_ACCOUNT=placeholder -e AZURE_STORAGE_KEY=placeholder -e AZURE_STORAGE_CONTAINER=placeholder hsl-jore-postgis
+```
+The command starts a hsl-jore-postgis container with a newly created volume `jore-data` running in the host port 5432. Follow the dump download and restore process with
+`docker logs -f hsl-jore-postgis`. If you want to re-download and restore the dump after initial restore, make sure to first remove the Docker volume `jore-data` with `docker volume rm jore-data` as the script runs only if a database does not already exist on the volume.

--- a/init.sh
+++ b/init.sh
@@ -7,19 +7,19 @@ account_secret=/run/secrets/AZURE_STORAGE_ACCOUNT
 
 # Check if the credentials exist.
 
-if [ ! -f $key_secret ]; then
+if [ ! -f $key_secret ] && [ ! -v AZURE_STORAGE_KEY ]; then
   echo "Azure key not set. Dump not downloaded."
   exit 0
 fi
 
-if [ ! -f $account_secret ]; then
+if [ ! -f $account_secret ] && [ ! -v AZURE_STORAGE_ACCOUNT ]; then
   echo "Azure account not set. Dump not downloaded."
   exit 0
 fi
 
-# Read the credentials so AZ CLI may use them.
-AZURE_STORAGE_KEY=$(<$key_secret)
-AZURE_STORAGE_ACCOUNT=$(<$account_secret)
+# Read the credentials so AZ CLI may use them. If no env variable is set use Docker secrets.
+AZURE_STORAGE_KEY=${AZURE_STORAGE_KEY:-$(<$key_secret)}
+AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT:-$(<$account_secret)}
 
 container_name=${AZURE_STORAGE_CONTAINER:=joredumps}
 


### PR DESCRIPTION
Add support for running the container without Docker secrets by giving required Azure-blob storage credentials as env-variables.